### PR TITLE
fix: Era's "World Buffs" row now tracks Chronoboon Displacer cooldown

### DIFF
--- a/SavedInstances/Modules/Currency.lua
+++ b/SavedInstances/Modules/Currency.lua
@@ -146,8 +146,7 @@ local allCurrencies = {
 local classicCurrencies = {
   -- Misc
   BINDING_HEADER_MISC,
-  212160, -- Chronoboon Displacer
-  
+  (SI.isSoD and 212160 or 184937), -- Chronoboon Displacer (SoD/Era specific)
   -- Holiday Currency
   CALENDAR_FILTER_WEEKLY_HOLIDAYS,
   19182, -- Darkmoon Faire Prize Ticket


### PR DESCRIPTION
- Support was added for SoD previously but I had not realized that Era and SoD used different itemIDs.
- known issues: __Will not__ be able to see SoD character's boon cds while in Era, and vice versa.