### PR TITLE
hotfix: handle cataclysm lua errors

### DIFF
--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -1152,7 +1152,7 @@ function Config:BuildAceConfigOptions()
     -- currently only classic era currencies had these headers to visually split currencies up.
     -- might add into wotlk/cata later
     local category = SI.currencyCategories[currencyID]
-    local categoryHeader = currencyOptions["CurrencyCategory"..category]
+    local categoryHeader = category and currencyOptions["CurrencyCategory"..category]
     if category and not categoryHeader then
       categoryHeader = {
         type = "header",

--- a/SavedInstances/Modules/WorldBuffs.lua
+++ b/SavedInstances/Modules/WorldBuffs.lua
@@ -7,6 +7,8 @@ local SI, L = unpack(select(2, ...))
 local Module = SI:NewModule('WorldBuffs', "AceEvent-3.0")
 local TooltipModule = SI:GetModule('Tooltip') --[[@as TooltipModule]]
 
+if not SI.isClassicEra then return end
+
 -- Global API
 local GetContainerItemCooldown = C_Container.GetContainerItemCooldown
 local RED = RED_FONT_COLOR ---@type ColorMixin


### PR DESCRIPTION
- fixed an error relating to the world buffs module trying to be used in cataclysm.
- fixed an error relating to the currency module.