### PR TITLE
[feat]: add dedicated darkmoon faire row

### DIFF
--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -619,6 +619,11 @@ function Config:BuildAceConfigOptions()
             order = 43.5,
             name = L["Weekly Quests"],
           },
+          TrackDarkmoonQuests = {
+            type = "toggle",
+            order = 43.6,
+            name = L["Darkmoon Quests"],
+          },
           TrackSkills = {
             type = "toggle",
             order = 43.7,


### PR DESCRIPTION
- previously (from original addon) they would get tracked in the "Weekly Quests" row
    - as a result the time left until the quest reset was misreported by the addon

**images**
![after](https://i.imgur.com/Ptx36sG.png)