### PR TITLE
[bugfix][cata]: fixed missing quests the "Daily Quest" category

### DIFF
--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -2496,7 +2496,7 @@ hoverTooltip.ShowQuestTooltip = function (cell, arg, ...)
     if (not isDaily) == (not qi.isDaily) then
       if not SI:QuestIgnored(id)
       -- only show darkmoon quest in darkmoon category
-      and (not QuestExceptions[id] == "Darkmoon" or isDMF)
+      and (not (QuestExceptions[id] == "Darkmoon") or isDMF)
       then
         zonename = qi.Zone and qi.Zone.name or ""
         table.insert(ql,zonename.." # "..id)


### PR DESCRIPTION
- fixed a bug introduced in the last update where hovering Daily Quests for the additional tooltip was no longer showing the names of the completed quests.