### PR TITLE
[feat][mop]: re-enabled bonus rolls tracking module

### DIFF
--- a/SavedInstances/Core/Config.lua
+++ b/SavedInstances/Core/Config.lua
@@ -638,8 +638,8 @@ function Config:BuildAceConfigOptions()
             type = "toggle",
             order = 43.8,
             name = L["Bonus rolls"],
-            disabled = not SI.isRetail,
-            hidden = not SI.isRetail,
+            disabled = SI.Enum.Expansion.Current < SI.Enum.Expansion.Mists,
+            hidden = SI.Enum.Expansion.Current < SI.Enum.Expansion.Mists,
           },
           AugmentBonus = {
             type = "toggle",

--- a/SavedInstances/Core/Core.lua
+++ b/SavedInstances/Core/Core.lua
@@ -122,6 +122,8 @@ local Tooltip = SI:GetModule('Tooltip')
 local Progress = SI:GetModule('Progress')
 local TradeSkill = SI:GetModule('TradeSkill')
 local Currency = SI:GetModule('Currency')
+local BonusRolls = SI:GetModule('BonusRolls', true) --[[@as BonusRollsModule?]]
+
 ---@cast Config ConfigModule
 ---@cast Tooltip TooltipModule
 ---@cast Progress ProgressModule
@@ -2812,9 +2814,26 @@ hoverTooltip.ShowBonusTooltip = function (cell, arg, ...)
   indicatortip:SetCell(1,3,L["Recent Bonus Rolls"],nil,"RIGHT",2)
 
   local line = indicatortip:AddLine()
+  local lastWeeklyReset = SI:GetNextWeeklyResetTime(-1)
+  local lastWeeklyRollIdx = 0
+  for _, roll in ipairs(t.BonusRoll) do
+    if roll.time and roll.time >= lastWeeklyReset then
+      lastWeeklyRollIdx = lastWeeklyRollIdx + 1
+    else
+      break;
+    end
+  end
+  local seperateWeeklyRolls = lastWeeklyRollIdx > 0
+  if seperateWeeklyRolls then
+    indicatortip:SetCell(line, 1, GUILD_CHALLENGES_THIS_WEEK, nil, "LEFT", 2)
+  end
   for i,roll in ipairs(t.BonusRoll) do
     if i > 10 then break end
     local line = indicatortip:AddLine()
+    if seperateWeeklyRolls and i == lastWeeklyRollIdx + 1 then
+      indicatortip:SetCell(line, 1, PREVIOUS, nil, "LEFT", 2)
+      line = indicatortip:AddLine()
+    end
     local icon = roll.costCurrencyID and (Currency.OverrideTexture[roll.costCurrencyID] or C_CurrencyInfo.GetCurrencyInfo(roll.costCurrencyID).iconFileID)
     if icon then
       indicatortip:SetCell(line,1, " \124T"..icon..":0\124t ")
@@ -3621,8 +3640,6 @@ function SI:OnEnable()
   self:RegisterBucketEvent("LFG_LOCK_INFO_RECEIVED", 1, RequestRaidInfo)
   self:RegisterEvent("PLAYER_LOGOUT", function() SI.logout = true ; SI:UpdateToonData() end) -- update currency spent
   self:RegisterEvent("LFG_COMPLETION_REWARD", "RefreshLockInfo") -- for random daily dungeon tracking
-  self:RegisterEvent("BOSS_KILL")
-  self:RegisterEvent("ENCOUNTER_END")
   self:RegisterEvent("TIME_PLAYED_MSG", function(_,total,level)
     local t = SI.thisToon and SI and SI.db and SI.db.Toons[SI.thisToon]
     if total > 0 and t then
@@ -3637,8 +3654,7 @@ function SI:OnEnable()
       SI.playedpending = false
     end
   end)
-  self:RegisterEvent("ADDON_LOADED")
-  SI:ADDON_LOADED()
+
   if not SI.resetDetect then
     SI.resetDetect = CreateFrame("Button", "SavedInstancesResetDetectHiddenFrame", UIParent)
     for _,e in pairs({
@@ -3655,21 +3671,6 @@ function SI:OnEnable()
   SI:HistoryEvent("PLAYER_ENTERING_WORLD") -- update after initial load
   SI:ValidateAndGetSpecialQuests()
   SI:updateRealmMap()
-end
-
-function SI:ADDON_LOADED()
-  if DBM and DBM.EndCombat and not SI.dbmhook then
-    SI.dbmhook = true
-    hooksecurefunc(DBM, "EndCombat", function(self, mod, wipe)
-      SI:BossModEncounterEnd("DBM:EndCombat", mod and mod.combatInfo and mod.combatInfo.name)
-    end)
-  end
-  if BigWigsLoader and not SI.bigwigshook then
-    SI.bigwigshook = true
-    BigWigsLoader.RegisterMessage(self, "BigWigs_OnBossWin", function(self, event, mod)
-      SI:BossModEncounterEnd("BigWigs_OnBossWin", mod and mod.displayName)
-    end)
-  end
 end
 
 function SI:OnDisable()
@@ -3765,64 +3766,6 @@ function SI:getRealmGroup(realmName)
   local realmMap = SI.db.RealmMap
   local connectedIdx = realmMap and realmMap[realmName]
   return connectedIdx, connectedIdx and realmMap[connectedIdx]
-end
-
---- Record a recent boss kill in the given `SI.db.Toon[toon]`'s data store.
----
---- I feel like this function is better defined here, in `Core.lua`, vs in `Modules/BonusRoll.lua`. 
---- Theres no expectation that the BonusRole module would be required for the `SI:BossModEncounterEnd` function.
---- @param toon string formatted as "Name - Server"
---- @param bossName string
---- @param difficultyID number
---- @param soft boolean?
-function SI:BossRecord(toon, bossName, difficultyID, soft)
-  ---@type SavedInstances.Toon
-  local toonData = SI.db.Toons[toon]
-  if not toonData then return end
-  local now = time()
-  
-  -- boss mods can often detect completion before ENCOUNTER_END
-  -- also some world bosses never send ENCOUNTER_END
-  -- enough timeout to prevent overwriting, but short enough to prevent cross-boss contamination
-  local lastKillTimestamp = toonData.lastbosstime or 0
-  if soft == false 
-    and (not bossName or now <= lastKillTimestamp + 120) 
-  then 
-    return
-  end
-  
-  bossName = tostring(bossName) -- for safety 
-  -- we should be confident its a string if code is well written.
-
-  local difficultyName = GetDifficultyInfo(difficultyID)
-  if difficultyName and #difficultyName > 0 then
-    bossName = bossName .. ": ".. difficultyName
-  end
-  toonData.lastboss = bossName
-  toonData.lastbosstime = now
-end
-
-function SI:BossModEncounterEnd(modname, bossname)
-  SI:Debug("%s refresh: %s", (modname or "BossMod"), tostring(bossname))
-  SI:BossRecord(SI.thisToon, bossname, select(3, GetInstanceInfo()), true)
-  self:RefreshLockInfo()
-end
-
-function SI:ENCOUNTER_END(event, encounterID, encounterName, difficultyID, raidSize, endStatus)
-  SI:Debug("ENCOUNTER_END:%s:%s:%s:%s:%s", tostring(encounterID), tostring(encounterName), tostring(difficultyID), tostring(raidSize), tostring(endStatus))
-  if endStatus ~= 1 then return end -- wipe
-  self:RefreshLockInfo()
-  SI:BossRecord(SI.thisToon, encounterName, difficultyID)
-end
-
-function SI:BOSS_KILL(event, encounterID, encounterName, ...)
-  SI:Debug("BOSS_KILL:%s:%s",tostring(encounterID),tostring(encounterName)) -- ..":"..strjoin(":",...))
-  local name = encounterName
-  if name and type(name) == "string" then
-    name = name:gsub(",.*$","") -- remove extraneous trailing boss titles
-    name = strtrim(name)
-    self:BossModEncounterEnd("BOSS_KILL", name)
-  end
 end
 
 --- Get the group type for the currently logged in character.
@@ -5552,36 +5495,36 @@ function SI:ShowTooltip(anchor)
         end
       end
     end
-    --- Bonus Rolls
-    if SI.db.Tooltip.TrackBonus or shouldShowAll then
-      local show
-      local toonbonus = localarr("toonbonus")
-      for toon, t in cpairs(SI.db.Toons, true) do
-        ---@diagnostic disable-next-line: undefined-field
-        local count = SI:BonusRollCount(toon)
-        if count then
-          toonbonus[toon] = count
-          show = true
-        end
+  end
+
+  --- Bonus Rolls
+  if BonusRolls and (SI.db.Tooltip.TrackBonus or shouldShowAll) then
+    local show
+    local toonbonus = localarr("toonbonus")
+    for toon, t in cpairs(SI.db.Toons, true) do
+      local count = BonusRolls:GetCharacterBadLuckStreak(toon)
+      if count then
+        toonbonus[toon] = count
+        show = true
       end
-      if show then
-        if SI.db.Tooltip.CategorySpaces then
-          addsep()
-        end
-        show = tooltip:AddLine(LIGHTYELLOW:WrapTextInColorCode(L["Roll Bonus"]))
+    end
+    if show then
+      if SI.db.Tooltip.CategorySpaces then
+        addsep()
       end
-      for toon, t in cpairs(SI.db.Toons, true) do
-        if toonbonus[toon] then
-          local col = characterColumns[toon..1]
-          local str = toonbonus[toon]
-          if str > 0 then str = "+"..str end
-          if col then
-            -- check if current toon is showing
-            -- don't add columns
-            tooltip:SetCell(show, col, ClassColorise(t.Class,str), nil, "CENTER", MAX_COL_PER_CHARACTER)
-            tooltip:SetCellScript(show, col, "OnEnter", hoverTooltip.ShowBonusTooltip, toon)
-            tooltip:SetCellScript(show, col, "OnLeave", CloseTooltips)
-          end
+      show = tooltip:AddLine(LIGHTYELLOW:WrapTextInColorCode(L["Roll Bonus"]))
+    end
+    for toon, t in cpairs(SI.db.Toons, true) do
+      if toonbonus[toon] then
+        local col = characterColumns[toon .. 1]
+        local str = toonbonus[toon]
+        if str > 0 then str = "+" .. str end
+        if col then
+          -- check if current toon is showing
+          -- don't add columns
+          tooltip:SetCell(show, col, ClassColorise(t.Class, str), nil, "CENTER", MAX_COL_PER_CHARACTER)
+          tooltip:SetCellScript(show, col, "OnEnter", hoverTooltip.ShowBonusTooltip, toon)
+          tooltip:SetCellScript(show, col, "OnLeave", CloseTooltips)
         end
       end
     end

--- a/SavedInstances/Core/Time.lua
+++ b/SavedInstances/Core/Time.lua
@@ -12,6 +12,8 @@ local C_Calendar_GetMonthInfo = C_Calendar.GetMonthInfo
 local C_Calendar_SetAbsMonth = C_Calendar.SetAbsMonth
 local GetQuestResetTime = GetQuestResetTime
 
+local ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60
+
 -- Current unix time minus the users system uptime (seconds).
 local systemStartTimestamp = time() - GetTime();
 
@@ -62,10 +64,15 @@ end
 
 SI.GetNextDailySkillResetTime = SI.GetNextDailyResetTime
 
---- Returns unix timestamp in seconds for the next weekly reset.
+---Gets the upcoming weekly reset timestamp.
+---@param offset number? optional offset in weeks
 ---@return number resetTimestamp
-function SI:GetNextWeeklyResetTime()
-  return time() + C_DateAndTime_GetSecondsUntilWeeklyReset()
+function SI:GetNextWeeklyResetTime(offset)
+  local secondsLeft = C_DateAndTime.GetSecondsUntilWeeklyReset()
+  if offset then
+    secondsLeft = secondsLeft + (offset * ONE_WEEK_IN_SECONDS)
+  end
+  return time() + secondsLeft
 end
 
 ---@param calenderTable CalendarTime

--- a/SavedInstances/Modules/BonusRoll.lua
+++ b/SavedInstances/Modules/BonusRoll.lua
@@ -1,12 +1,13 @@
+---@class SavedInstances
 local SI, L = unpack((select(2, ...)))
-local Module = SI:NewModule('BonusRoll', 'AceEvent-3.0')
+if SI.Enum.Expansion.Current < SI.Enum.Expansion.Mists then return end
+
+---@class BonusRollsModule: AceModule, AceEvent-3.0
+local Module = SI:NewModule('BonusRolls', 'AceEvent-3.0')
 
 local BonusFrame -- Frame attached to BonusRollFrame
 local MAX_BONUS_ROLL_RECORD_LIMIT = 25 -- the max cap of bonus roll records
-local BONUS_ROLL_REQUIRED_CURRENCY = 1580 -- bonus roll currency of current expansion
-local ignoreItem = {
-  [163827] = true, -- Quartermaster's Coin, obtained when failing a bonus roll in pvp
-}
+local BONUS_ROLL_REQUIRED_CURRENCY = BONUS_ROLL_REQUIRED_CURRENCY -- bonus roll currency of current expansion
 
 -- Lua functions
 local tostring, ipairs, time, pairs, strsplit = tostring, ipairs, time, pairs, strsplit
@@ -27,7 +28,7 @@ local function BonusRollShow()
   local t = SI.db.Toons[SI.thisToon]
   local BonusRollFrame = _G.BonusRollFrame
   if not t or not BonusRollFrame then return end
-  local bonus = SI:BonusRollCount(SI.thisToon, BonusRollFrame.CurrentCountFrame.currencyID)
+  local bonus = Module:GetCharacterWeeklyRollCount(SI.thisToon, BonusRollFrame.currencyID)
   if not bonus or not SI.db.Tooltip.AugmentBonus then
     if BonusFrame then BonusFrame:Hide() end
     return
@@ -57,6 +58,9 @@ function Module:OnEnable()
   BonusRollShow() -- catch roll-on-load
   self:RegisterEvent("BONUS_ROLL_RESULT")
   self:RegisterEvent("CHAT_MSG_MONSTER_YELL")
+  self:RegisterEvent("ENCOUNTER_END")
+  self:RegisterEvent("BOSS_KILL")
+  -- self:RegisterEvent("ADDON_LOADED") -- disabled due to reporting world bosses with `nil` as name
 end
 
 function Module:CHAT_MSG_MONSTER_YELL(event, msg, bossname)
@@ -74,6 +78,86 @@ function Module:CHAT_MSG_MONSTER_YELL(event, msg, bossname)
   end
 end
 
+local getCurrentInstanceDifficulty = function()
+  local difficultyID = GetBonusRollEncounterJournalLinkDifficulty and GetBonusRollEncounterJournalLinkDifficulty()
+  if not difficultyID or difficultyID <= 0 then
+    difficultyID = select(3, GetInstanceInfo())
+  end
+  return difficultyID
+end
+
+--- Record a recent boss kill in the given `SI.db.Toon[toon]`'s data store.
+--- Used to track the correct recent boss to associate a bonus roll with.
+--- @param toon string formatted as "Name - Server"
+--- @param bossName string
+--- @param difficultyID number
+--- @param soft boolean?
+local function recordBossToSavedVars(toon, bossName, difficultyID, soft)
+  ---@type SavedInstances.Toon
+  local toonData = SI.db.Toons[toon]
+  if not toonData then return end
+  local now = time()
+
+  -- Note: some world bosses never send ENCOUNTER_END
+  -- enough timeout to prevent overwriting, but short enough to prevent cross-boss contamination
+  local lastKillTimestamp = toonData.lastbosstime or 0
+  if soft == false
+      and (not bossName or now <= lastKillTimestamp + 120)
+  then
+    return
+  end
+
+  local difficultyName = GetDifficultyInfo(difficultyID)
+  if difficultyName and #difficultyName > 0 then
+    bossName = bossName .. ": " .. difficultyName
+  end
+  toonData.lastboss = bossName
+  toonData.lastbosstime = now
+end
+
+function Module:ENCOUNTER_END(event, encounterID, encounterName, difficultyID, raidSize, endStatus)
+  SI:Debug("ENCOUNTER_END:%s:%s:%s:%s:%s",
+    tostring(encounterID), tostring(encounterName), tostring(difficultyID), tostring(raidSize), tostring(endStatus)
+  )
+  if endStatus ~= 1 then return end -- wipe
+  recordBossToSavedVars(SI.thisToon, tostring(encounterName), difficultyID)
+  SI:RefreshLockInfo()
+end
+---@param encounterName string
+function Module:BOSS_KILL(event, encounterID, encounterName, ...)
+  SI:Debug("BOSS_KILL:%s:%s", tostring(encounterID), tostring(encounterName)) -- ..":"..strjoin(":",...))
+  if encounterName and type(encounterName) == "string" then
+    encounterName = encounterName:gsub(",.*$", "")                          -- remove extraneous trailing boss titles
+    encounterName = strtrim(encounterName)
+    recordBossToSavedVars(SI.thisToon, encounterName, getCurrentInstanceDifficulty(), true)
+    SI:RefreshLockInfo()
+  end
+end
+
+local handleBossModsEncounterEndEvent = function(source, bossName)
+  SI:Debug("Boss Mod Kill - %s: %s", tostring(source), tostring(bossName))
+  if not bossName or #bossName == 0 then return end
+  recordBossToSavedVars(SI.thisToon, bossName, getCurrentInstanceDifficulty(), true)
+  SI:RefreshLockInfo()
+end
+
+function Module:ADDON_LOADED(event, addonName)
+  if DBM and DBM.EndCombat and not SI.dbmhook then
+    SI.dbmhook = true
+    hooksecurefunc(DBM, "EndCombat", function(self, mod, wipe)
+      if wipe then return end -- ignore wipes
+      local bossName = mod and mod.combatInfo and mod.combatInfo.name
+      handleBossModsEncounterEndEvent("DBM:EndCombat", bossName)
+    end)
+  end
+  if BigWigsLoader and not SI.bigwigshook then
+    SI.bigwigshook = true
+    BigWigsLoader.RegisterMessage(self, "BigWigs_OnBossWin", function(self, event, mod)
+      handleBossModsEncounterEndEvent("BigWigs_OnBossWin", mod and mod.displayName)
+    end)
+  end
+end
+
 function Module:BONUS_ROLL_RESULT(event, rewardType, rewardLink, rewardQuantity, rewardSpecID, _, _, currencyID)
   local t = SI.db.Toons[SI.thisToon]
   SI:Debug("BONUS_ROLL_RESULT:%s:%s:%s:%s (boss=%s|%s)",
@@ -85,26 +169,26 @@ function Module:BONUS_ROLL_RESULT(event, rewardType, rewardLink, rewardQuantity,
   local now = time()
   local bossname
   -- Mythic+ Dungeon Roll
-  if GetBonusRollEncounterJournalLinkDifficulty() == DifficultyUtil_ID_DungeonChallenge then
-    local name, _, difficultyID, difficultyName = GetInstanceInfo()
-    if difficultyID == DifficultyUtil_ID_DungeonChallenge then
-      bossname = name .. ": " .. difficultyName
-    else
-      local tmp = {}
-      for key, value in pairs(SI.db.History) do
-        local _, name, _, diff = strsplit(":", key)
-        if tonumber(diff) == DifficultyUtil_ID_DungeonChallenge then
-          local tbl = {
-            name = name .. ": " .. GetDifficultyInfo(diff),
-            last = value.last,
-          }
-          tinsert(tmp, tbl)
-        end
-      end
-      sort(tmp, function(l, r) return l.last > r.last end)
-      bossname = tmp[1] and tmp[1].name
-    end
-  end
+  -- if GetBonusRollEncounterJournalLinkDifficulty() == DifficultyUtil_ID_DungeonChallenge then
+  --   local name, _, difficultyID, difficultyName = GetInstanceInfo()
+  --   if difficultyID == DifficultyUtil_ID_DungeonChallenge then
+  --     bossname = name .. ": " .. difficultyName
+  --   else
+  --     local tmp = {}
+  --     for key, value in pairs(SI.db.History) do
+  --       local _, name, _, diff = strsplit(":", key)
+  --       if tonumber(diff) == DifficultyUtil_ID_DungeonChallenge then
+  --         local tbl = {
+  --           name = name .. ": " .. GetDifficultyInfo(diff),
+  --           last = value.last,
+  --         }
+  --         tinsert(tmp, tbl)
+  --       end
+  --     end
+  --     sort(tmp, function(l, r) return l.last > r.last end)
+  --     bossname = tmp[1] and tmp[1].name
+  --   end
+  -- end
   if not bossname then
     bossname = t.lastboss
     if now > (t.lastbosstime or 0) + 3*60 then
@@ -121,7 +205,7 @@ function Module:BONUS_ROLL_RESULT(event, rewardType, rewardLink, rewardQuantity,
   local roll = {
     name = bossname,
     time = now,
-    costCurrencyID = _G.BonusRollFrame.CurrentCountFrame.currencyID,
+    costCurrencyID = _G.BonusRollFrame.currencyID,
   }
   if rewardType == "money" then
     roll.money = rewardQuantity
@@ -137,42 +221,45 @@ function Module:BONUS_ROLL_RESULT(event, rewardType, rewardLink, rewardQuantity,
   end
 end
 
-function SI:BonusRollCount(toon, currencyID)
+---@param toon string name of the character to query
+---@param currencyID number? bonus roll currency id, defaults to `BONUS_ROLL_REQUIRED_CURRENCY`
+function Module:GetCharacterWeeklyRollCount(toon, currencyID)
   local t = SI.db.Toons[toon]
   if not t or not t.BonusRoll or #t.BonusRoll == 0 then return end
-  currencyID = currencyID or BONUS_ROLL_REQUIRED_CURRENCY
+  if not currencyID or currencyID == 0 then currencyID = BONUS_ROLL_REQUIRED_CURRENCY end
   local count = 0
-  for _, tbl in ipairs(t.BonusRoll) do
-    if not tbl.costCurrencyID then break end
-    if tbl.costCurrencyID == currencyID then
-      if not tbl.item then
+  local lastWeekReset = SI:GetNextWeeklyResetTime(-1)
+  for _, trackedRoll in ipairs(t.BonusRoll) do
+    if trackedRoll.costCurrencyID and trackedRoll.costCurrencyID == currencyID then
+      if trackedRoll.time >= lastWeekReset then
         count = count + 1
-      else
-        local itemID = GetItemInfoInstant(tbl.item)
-        if ignoreItem[itemID] then
-          count = count + 1
-        else
-          break
-        end
       end
     end
   end
   return count
 end
 
-function SI:BossRecord(toon, bossname, difficultyID, soft)
+local ignoredBonusItems = {
+  [163827] = true, -- Quartermaster's Coin, obtained when failing a bonus roll in pvp
+
+  -- Unsure if the follow items count toward bad luck protection or not.
+  [90839] = false, -- Cache of Sha-Touched Gold
+  [90840] = false, -- Marauder's Gleaming Sack of Gold
+}
+---Number of times character has gotten gold or an item that counts towards BLP
+---@return number? # nil if no bonus roll history found for character
+function Module:GetCharacterBadLuckStreak(toon, currencyID)
   local t = SI.db.Toons[toon]
-  if not t then return end
-  local now = time()
-  -- boss mods can often detect completion before ENCOUNTER_END
-  -- also some world bosses never send ENCOUNTER_END
-  -- enough timeout to prevent overwriting, but short enough to prevent cross-boss contamination
-  if soft and soft == false and (not bossname or now <= (t.lastbosstime or 0) + 120) then return end
-  bossname = tostring(bossname) -- for safety
-  local difficultyName = GetDifficultyInfo(difficultyID)
-  if difficultyName and #difficultyName > 0 then
-    bossname = bossname .. ": ".. difficultyName
+  if not t or not t.BonusRoll or #t.BonusRoll == 0 then return end
+  local count = 0
+  for _, trackedRoll in ipairs(t.BonusRoll) do
+    if trackedRoll.costCurrencyID and trackedRoll.costCurrencyID == currencyID then
+        if (not trackedRoll.item and trackedRoll.money and trackedRoll.money > 0)
+        or (trackedRoll.item and ignoredBonusItems[GetItemInfoInstant(trackedRoll.item)])
+        then
+          count = count + 1
+        else break; end
+    end
   end
-  t.lastboss = bossname
-  t.lastbosstime = now
+  return count
 end

--- a/SavedInstances/SavedInstances.toc
+++ b/SavedInstances/SavedInstances.toc
@@ -32,7 +32,7 @@ Modules\Quest.lua
 Modules\Currency.lua
 Modules\Progress.lua
 Modules\TradeSkill.lua
-# Modules\BonusRoll.lua
+Modules\BonusRoll.lua
 # Modules\Calling.lua
 # Modules\Emissary.lua
 # Modules\LFR.lua


### PR DESCRIPTION
- disabled bossmod tracking for boss kills untill i figure out the bug causing lastbossname to be ""
- addon bonus roll row will display number of recent "bad luck" rolls for each character.